### PR TITLE
ARM template changes to set enableHttpsTrafficOnly: true for storage

### DIFF
--- a/arm-deployment/devicesimulation-nohub/armtemplate/template.json
+++ b/arm-deployment/devicesimulation-nohub/armtemplate/template.json
@@ -399,7 +399,8 @@
             },
             "tags": {
                 "IotSuiteType": "[parameters('solutionType')]"
-            }
+            },
+            "enableHttpsTrafficOnly": true
         },
       {
         "comments": "Security rules used for the VM network interface",

--- a/arm-deployment/devicesimulation/armtemplate/template.json
+++ b/arm-deployment/devicesimulation/armtemplate/template.json
@@ -455,7 +455,8 @@
       },
       "tags": {
           "IotSuiteType": "[parameters('solutionType')]"
-      }
+      },
+      "enableHttpsTrafficOnly": true
     },
     {
       "comments": "Security rules used for the VM network interface",


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

There is a storage account setting to require secure transfers to the account (and reject non-secured ones). If a subscription has this setting/policy enabled globally, deployment of storage accounts will fail, and the Sim deployment will fail.

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
