### PR TITLE
Sim Improvements: Change VMSS upgrade policy to 'Automatic' and only build images that are needed.

### DIFF
--- a/arm-deployment/devicesimulation-nohub/armtemplate/template.json
+++ b/arm-deployment/devicesimulation-nohub/armtemplate/template.json
@@ -566,7 +566,7 @@
         "properties": {
           "overprovision": "false",
           "upgradePolicy": {
-            "mode": "Manual"
+            "mode": "Automatic"
           },
           "virtualMachineProfile": {
             "storageProfile": {

--- a/arm-deployment/devicesimulation/armtemplate/template.json
+++ b/arm-deployment/devicesimulation/armtemplate/template.json
@@ -622,7 +622,7 @@
       "properties": {
         "overprovision": "false",
         "upgradePolicy": {
-          "mode": "Manual"
+          "mode": "Automatic"
         },
         "virtualMachineProfile": {
           "storageProfile": {

--- a/scripts/git/release.sh
+++ b/scripts/git/release.sh
@@ -161,11 +161,14 @@ tag_build_publish_repo() {
 check_input
 
 # DOTNET Microservices
+# As of DS-2.0.6, only the Web UI and the Simulation service containers are
+# refrenced by a new docker tag for each release (in docker-compse.yaml in the
+# deployed VMs)
 tag_build_publish_repo simulation-service     device-simulation-dotnet
-tag_build_publish_repo pcs-diagnostics-dotnet pcs-diagnostics-dotnet
-tag_build_publish_repo storage-service        pcs-storage-adapter-dotnet
 tag_build_publish_repo webui                  pcs-simulation-webui              device-simulation-webui
-tag_build_publish_repo pcs-config-dotnet      pcs-config-dotnet
-tag_build_publish_repo api-gateway            azure-iot-pcs-device-simulation   simulation-api-gateway
+#tag_build_publish_repo pcs-diagnostics-dotnet pcs-diagnostics-dotnet
+#tag_build_publish_repo storage-service        pcs-storage-adapter-dotnet
+#tag_build_publish_repo pcs-config-dotnet      pcs-config-dotnet
+#tag_build_publish_repo api-gateway            azure-iot-pcs-device-simulation   simulation-api-gateway
 
 set +e


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

There have been a number of Simulation deployments that have failed recently, due to the subscription that they were attempting to deploy to having a subscription policy that would not allow VMs to be created that did not have their 'upgradePolicy' flag set to 'Automatic'.

(see https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/2019-07-01/virtualmachinescalesets#UpgradePolicy)

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
