### PR TITLE
Hard coding the docker tag for the Web UI

### DIFF
--- a/arm-deployment/devicesimulation-nohub/single-vm/docker-compose.yml
+++ b/arm-deployment/devicesimulation-nohub/single-vm/docker-compose.yml
@@ -35,7 +35,7 @@ services:
         max-file: "10"
 
   webui-svc:
-    image: azureiotpcs/device-simulation-webui:${PCS_DOCKER_TAG}
+    image: azureiotpcs/device-simulation-webui:DS-2.0.6
     restart: always
     depends_on:
       - devicesimulation-svc

--- a/arm-deployment/devicesimulation/single-vm/docker-compose.yml
+++ b/arm-deployment/devicesimulation/single-vm/docker-compose.yml
@@ -35,7 +35,7 @@ services:
         max-file: "10"
 
   webui-svc:
-    image: azureiotpcs/device-simulation-webui:${PCS_DOCKER_TAG}
+    image: azureiotpcs/device-simulation-webui:DS-2.0.6
     restart: always
     depends_on:
       - devicesimulation-svc


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->

The private CIDC pipeline that Microsoft uses is currently blocked due to authentication policy changes in the Azure organization on GitHub. The CICD pipeline builds each microservice and pushes the resulting images to DockerHub. Because this process is blocked, I'm changing the way that containers are referenced in the docker-compose.yaml file for the Web UI container, as we don't expect to rebuild and re-publish this container frequently. 

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
